### PR TITLE
Add Warning for Endpoint Mismatch in OTLP GRPC Exporter

### DIFF
--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/exporter.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/exporter.py
@@ -185,7 +185,12 @@ class OTLPExporterMixin(
 
         if parsed_url.netloc:
             self._endpoint = parsed_url.netloc
-
+            if parsed_url.path:
+                logger.warning(
+                    f"Endpoint set to {self._endpoint}, which differs from the "
+                    f"provided endpoint {endpoint}. If you're trying to configure "
+                    f"an HTTP endpoint, please ensure you're using the correct exporter."
+                )
         self._headers = headers or environ.get(OTEL_EXPORTER_OTLP_HEADERS)
         if isinstance(self._headers, str):
             temp_headers = parse_env_headers(self._headers)


### PR DESCRIPTION
This commit introduces a warning message in the OTLP GRPC Exporter when there is a mismatch between the configured endpoint and the provided endpoint. This change aims to prevent silent truncation of the endpoint value, which could lead to confusion and time-consuming debugging for users trying to configure a HTTP exporter but mistakenly passing a GRPC one. This issue might be a common occurrence for newcomers, as almost all the examples use the GRPC exporter. The warning message provides clear, actionable feedback to the user, improving the overall user experience.

Addresses https://github.com/open-telemetry/opentelemetry-python/issues/3619

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Added logger warning

# How Has This Been Tested?

Verified that the warning gets displayed when an URL with path was passed (`https://otlp.endpoint.com:4317/v1/traces`) and no warning was displayed when an expected grpc endpoint like (`http://localhost:4317`) was passed.

# Does This PR Require a Contrib Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
